### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=MCP4251
 version=0.0.0
-author=Sergio Díaz
-maintainer=Sergio Díaz
+author=David Díaz
+maintainer=David Díaz
 sentence=Control the MCP4251 digital potentiometer.
 paragraph=
 category=Device Control

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=MCP4251
+version=0.0.0
+author=Sergio Díaz
+maintainer=Sergio Díaz
+sentence=Control the MCP4251 digital potentiometer.
+paragraph=
+category=Device Control
+url=https://github.com/Seich/mcp4251
+architectures=*
+includes=mcp4251.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata